### PR TITLE
Enable jekyll-feed plugin

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -14,6 +14,8 @@ markdown: kramdown
 highlighter: rouge
 permalink: pretty
 include: [.well-known]
+plugins:
+  - jekyll-feed
 
 boxes:
   - title: download


### PR DESCRIPTION
The jekyll-feed (supported by GitHub Pages) plugin makes jekyll feeds available via RSS at /feed.xml

You can see an example of it working at https://ritzow.github.io/spdk.github.io/feed.xml

Here's some more info about enabling the plugin: https://dzhavat.github.io/2020/01/19/adding-an-rss-feed-to-github-pages.html

Here's what it looks like in the Reeder app for iOS:

![iOS reeder view of https://ritzow.github.io/spdk.github.io/feed.xml](https://github.com/spdk/spdk.github.io/assets/11698787/64bc5111-153f-4a37-b0e8-9ce51de51971)

